### PR TITLE
Composer, Prefer Source for Dev

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ $ git checkout -b bug-or-feature-description
 And install the dependencies:
 
 ```bash
-$ composer install
+$ composer install --prefer-source
 ```
 
 Write your code and add tests. Then run the tests:


### PR DESCRIPTION
Updates the contributing setup steps to include `--prefer-source` for `composer install` (as the test files are needed from `portphp/portphp` which get excluded from the dist version).