### PR TITLE
move valid check to beginning of loop

### DIFF
--- a/src/CsvReader.php
+++ b/src/CsvReader.php
@@ -112,7 +112,7 @@ class CsvReader implements CountableReader, \SeekableIterator
         }
 
         // Since the CSV has column headers use them to construct an associative array for the columns in this line
-        do {
+        while($this->valid()) {
             $line = $this->file->current();
 
             // In non-strict mode pad/slice the line to match the column headers
@@ -139,7 +139,7 @@ class CsvReader implements CountableReader, \SeekableIterator
                 $this->errors[$this->key()] = $line;
                 $this->next();
             }
-        } while($this->valid());
+        }
 
         return null;
     }


### PR DESCRIPTION
I'm seeing an issue with a CSV I have where this line
https://github.com/portphp/csv/blob/master/src/CsvReader.php#L116
is coming back as false on the last line.
Switching the do while to a while loop fixes this, but I can't work out why it's happening or replicate it in a test.

Anyway, it doesn't break any existing tests.