### PR TITLE
PHP8 READ_AHEAD fix

### DIFF
--- a/src/CsvReader.php
+++ b/src/CsvReader.php
@@ -200,7 +200,9 @@ class CsvReader implements CountableReader, \SeekableIterator
     {
         $this->file->rewind();
         if (null !== $this->headerRowNumber) {
-            $this->file->seek($this->headerRowNumber + 1);
+            for ($i = 0; $i <= $this->headerRowNumber; $i++) {
+                $this->file->next();
+            }
         }
     }
 


### PR DESCRIPTION
When `$i > 0`, `$this->file->seek($i)` returns false and foreach is never executed.