### PR TITLE
Allow configuring escape for `CsvWriter`

### DIFF
--- a/src/CsvWriter.php
+++ b/src/CsvWriter.php
@@ -34,13 +34,19 @@ class CsvWriter extends AbstractStreamWriter
     protected $prependHeaderRow;
 
     /**
+     * @var string
+     */
+    private $escape;
+
+    /**
      * @param string   $delimiter The delimiter
      * @param string   $enclosure The enclosure
      * @param resource $stream
      * @param boolean  $utf8Encoding
      * @param boolean  $prependHeaderRow
+     * @param string   $escape
      */
-    public function __construct($delimiter = ',', $enclosure = '"', $stream = null, $utf8Encoding = false, $prependHeaderRow = false)
+    public function __construct($delimiter = ',', $enclosure = '"', $stream = null, $utf8Encoding = false, $prependHeaderRow = false, $escape = '\\')
     {
         parent::__construct($stream);
 
@@ -48,6 +54,7 @@ class CsvWriter extends AbstractStreamWriter
         $this->enclosure = $enclosure;
         $this->utf8Encoding = $utf8Encoding;
         $this->prependHeaderRow = $prependHeaderRow;
+        $this->escape = $escape;
     }
 
     /**
@@ -67,9 +74,9 @@ class CsvWriter extends AbstractStreamWriter
     {
         if ($this->prependHeaderRow && 1 == $this->row++) {
             $headers = array_keys($item);
-            fputcsv($this->getStream(), $headers, $this->delimiter, $this->enclosure);
+            fputcsv($this->getStream(), $headers, $this->delimiter, $this->enclosure, $this->escape);
         }
 
-        fputcsv($this->getStream(), $item, $this->delimiter, $this->enclosure);
+        fputcsv($this->getStream(), $item, $this->delimiter, $this->enclosure, $this->escape);
     }
 }


### PR DESCRIPTION
PHP 8.4 deprecates calls to `fputcsv` that don't pass `''` as the `$escape` argument. Without this change, it's impossible to avoid a deprecation warning when using `CsvWriter`.

If a new major version of this library is released, it should change the default to empty string to avoid the warning by default.