### PR TITLE
CI: modernize GitHub Actions (PHP 8.2–8.5)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,48 +6,42 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
-        php-versions: [ '7.4', '8.0', '8.1' ]
-        include:
-          - php-versions: '7.4'
-            coverage: pcov
-            composer-prefer: '--prefer-lowest --prefer-stable'
-            phpunit-flags: '--coverage-clover coverage.xml'
+        php-versions: [ '8.2', '8.3', '8.4', '8.5' ]
 
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          coverage: ${{ matrix.coverage }}
+          coverage: none
+          tools: composer:v2
 
-      - name: Validate composer.json and composer.lock
-        run: composer validate --strict
+
+      - name: Validate composer.json
+        run: composer validate --strict --no-check-lock
 
       - name: Cache Composer packages
-        id: composer-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: vendor
-          key: ${{ runner.os }}-composer-${{ matrix.composer-prefer }}$-${{ hashFiles('**/composer.lock') }}
+          key: ${{ runner.os }}-composer-${{ matrix.php-versions }}-${{ hashFiles('**/composer.json') }}
           restore-keys: |
-            ${{ runner.os }}-composer-${{ matrix.composer-prefer }}-
+            ${{ runner.os }}-composer-${{ matrix.php-versions }}-
 
       - name: Install dependencies
-        run: composer update --prefer-dist --no-progress ${{ matrix.composer-prefer }}
+        run: composer update --prefer-dist --no-progress
 
       - name: Run test suite
-        run: vendor/bin/phpunit ${{ matrix.phpunit-flags }}
-
-      - name: Upload coverage
-        if: matrix.coverage
-        run: |
-          wget https://scrutinizer-ci.com/ocular.phar
-          php ocular.phar code-coverage:upload --format=php-clover coverage.xml --revision=${{ github.event.pull_request.head.sha || github.sha }}
+        run: vendor/bin/phpunit


### PR DESCRIPTION
## Summary
Phase 0 housekeeping for green, maintainable CI.

- Bump `actions/checkout` and `actions/cache` to **v4**
- Matrix: **PHP 8.2–8.5**
- Remove Scrutinizer/ocular upload

Part of PortPHP org CI modernization (Phase 0).