### PR TITLE
Address Copilot CI feedback from #11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,12 +29,12 @@ jobs:
           tools: composer:v2
 
 
-      - name: Validate composer.json
+      - name: Validate Composer metadata
         run: |
           if [ -f composer.lock ]; then
-            composer validate --strict
+            composer validate --strict --no-interaction
           else
-            composer validate --strict --no-check-lock
+            composer validate --strict --no-check-lock --no-interaction
           fi
 
       - name: Cache Composer packages
@@ -48,9 +48,9 @@ jobs:
       - name: Install dependencies
         run: |
           if [ -f composer.lock ]; then
-            composer install --prefer-dist --no-progress
+            composer install --prefer-dist --no-progress --no-interaction
           else
-            composer update --prefer-dist --no-progress
+            composer update --prefer-dist --no-progress --no-interaction
           fi
 
       - name: Run test suite

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,12 @@ jobs:
             ${{ runner.os }}-composer-${{ matrix.php-versions }}-
 
       - name: Install dependencies
-        run: composer update --prefer-dist --no-progress
+        run: |
+          if [ -f composer.lock ]; then
+            composer install --prefer-dist --no-progress
+          else
+            composer update --prefer-dist --no-progress
+          fi
 
       - name: Run test suite
         run: vendor/bin/phpunit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,13 +30,18 @@ jobs:
 
 
       - name: Validate composer.json
-        run: composer validate --strict --no-check-lock
+        run: |
+          if [ -f composer.lock ]; then
+            composer validate --strict
+          else
+            composer validate --strict --no-check-lock
+          fi
 
       - name: Cache Composer packages
         uses: actions/cache@v4
         with:
           path: vendor
-          key: ${{ runner.os }}-composer-${{ matrix.php-versions }}-${{ hashFiles('**/composer.json') }}
+          key: ${{ runner.os }}-composer-${{ matrix.php-versions }}-${{ hashFiles('**/composer.json', '**/composer.lock') }}
           restore-keys: |
             ${{ runner.os }}-composer-${{ matrix.php-versions }}-
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "docs": "https://portphp.readthedocs.org"
     },
     "require": {
-        "php": ">=8.2",
+        "php": "^8.2",
         "portphp/portphp": "^1.6.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "docs": "https://portphp.readthedocs.org"
     },
     "require": {
+        "php": ">=8.2",
         "portphp/portphp": "^1.6.0"
     },
     "autoload": {


### PR DESCRIPTION
## Summary
Follow-up to #11 addressing Copilot review comments.

- Declare `"php": "^8.2"` to match the tested matrix (excludes PHP 9+ by default)
- Validate `composer.lock` when present
- Prefer `composer install` when a lockfile is present
- Hash both `composer.json` and `composer.lock` in the cache key
- Run Composer with `--no-interaction`

## Test plan
- [x] CI matrix PHP 8.2–8.5 green
- [x] Copilot review on latest commit