### PR TITLE
Update README CI badges and drop Scrutinizer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,8 +3,6 @@ tests/           export-ignore
 .editorconfig    export-ignore
 .gitattributes   export-ignore
 .gitignore       export-ignore
-.scrutinizer.yml export-ignore
-.travis.yml      export-ignore
 CONTRIBUTING.md  export-ignore
 phpspec.yml.dist export-ignore
 phpunit.xml.dist export-ignore

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,7 +1,0 @@
-checks:
-  php:
-    code_rating: true
-    duplication: true
-
-tools:
-  external_code_coverage: true

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # portphp/csv
 
 [![Latest Version](https://img.shields.io/github/release/portphp/csv.svg?style=flat-square)](https://github.com/portphp/csv/releases)
-[![Build Status](https://travis-ci.org/portphp/csv.svg)](https://travis-ci.org/portphp/csv)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/portphp/csv/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/portphp/csv/?branch=master)
-[![Code Coverage](https://scrutinizer-ci.com/g/portphp/csv/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/portphp/csv/?branch=master)
+[![CI](https://github.com/portphp/csv/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/portphp/csv/actions)
+[![PHP Version](https://img.shields.io/packagist/php-v/portphp/csv.svg?style=flat-square)](https://packagist.org/packages/portphp/csv)
 
-CVS reader and writer for [Port](https://github.com/portphp).
+**Requirements:** PHP ^8.2 (tested on 8.2–8.5).
+
+
+CSV reader and writer for [Port](https://github.com/portphp).
 
 ## Installation
 
@@ -22,7 +24,7 @@ of the Composer documentation.
 
 ## Documentation
 
-Documentation is available at https://portphp.readthedocs.org.
+Documentation is available at https://portphp.readthedocs.io.
 
 ## Issues and feature requests
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # portphp/csv
 
 [![Latest Version](https://img.shields.io/github/release/portphp/csv.svg?style=flat-square)](https://github.com/portphp/csv/releases)
-[![CI](https://github.com/portphp/csv/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/portphp/csv/actions)
+[![CI](https://github.com/portphp/csv/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/portphp/csv/actions/workflows/test.yml)
 [![PHP Version](https://img.shields.io/packagist/php-v/portphp/csv.svg?style=flat-square)](https://packagist.org/packages/portphp/csv)
 
 **Requirements:** PHP ^8.2 (tested on 8.2–8.5).

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "support": {
         "issues": "https://github.com/portphp/portphp/issues",
         "source": "https://github.com/portphp/csv",
-        "docs": "https://portphp.readthedocs.org"
+        "docs": "https://portphp.readthedocs.io"
     },
     "require": {
         "php": "^8.2",


### PR DESCRIPTION
## Summary
- Replace Travis/Scrutinizer badges with GitHub Actions
- Document PHP ^8.2 requirements
- Fix docs URL; fix "CVS" → "CSV" typo
- Remove `.scrutinizer.yml`

## Test plan
- [x] CI green
- [ ] Copilot review