### PR TITLE
Release 3.0.0: PHP ^8.2 and portphp/portphp ^2.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+  - package-ecosystem: composer
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5
+    versioning-strategy: widen

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -1,0 +1,4 @@
+# Upgrade from 2.x to 3.0
+
+- Minimum PHP is **8.2** (`^8.2`).
+- Requires `portphp/portphp` **^2.0**.

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.2",
-        "portphp/portphp": "^1.6.0"
+        "portphp/portphp": "^2.0"
     },
     "autoload": {
         "psr-4": {
@@ -32,7 +32,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.6"
     },
     "autoload-dev": {
         "psr-4": {
@@ -41,7 +41,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0.x-dev"
+            "dev-master": "3.0.x-dev"
         }
     }
 }

--- a/src/CsvReaderFactory.php
+++ b/src/CsvReaderFactory.php
@@ -2,6 +2,7 @@
 
 namespace Port\Csv;
 
+use Port\Reader;
 use Port\Reader\ReaderFactory;
 
 /**
@@ -62,7 +63,7 @@ class CsvReaderFactory implements ReaderFactory
      *
      * @return CsvReader
      */
-    public function getReader(\SplFileObject $file)
+    public function getReader(\SplFileObject $file): Reader
     {
         $reader = new CsvReader($file, $this->delimiter, $this->enclosure, $this->escape);
 

--- a/src/CsvWriter.php
+++ b/src/CsvWriter.php
@@ -53,7 +53,7 @@ class CsvWriter extends AbstractStreamWriter
     /**
      * {@inheritdoc}
      */
-    public function prepare()
+    public function prepare(): void
     {
         if ($this->utf8Encoding) {
             fprintf($this->getStream(), chr(0xEF) . chr(0xBB) . chr(0xBF));
@@ -63,7 +63,7 @@ class CsvWriter extends AbstractStreamWriter
     /**
      * {@inheritdoc}
      */
-    public function writeItem(array $item)
+    public function writeItem(array $item): void
     {
         if ($this->prependHeaderRow && 1 == $this->row++) {
             $headers = array_keys($item);


### PR DESCRIPTION
## Summary
**Major** (2.x → 3.0) aligned with `portphp/portphp` 2.0.0.

### Breaking
- `php`: `^8.2`
- `portphp/portphp`: `^2.0` (was `^1.6`)

### Other
- Dependabot, `UPGRADE-3.0.md`, branch-alias `3.0.x-dev`

## Test plan
- [ ] CI
- [ ] Copilot