### PR TITLE
Fix CsvReader::current() TypeError at EOF (with regression tests)

### DIFF
--- a/src/CsvReader.php
+++ b/src/CsvReader.php
@@ -107,8 +107,11 @@ class CsvReader implements CountableReader, \SeekableIterator
             return $this->file->current();
         }
 
-        // Since the CSV has column headers use them to construct an associative array for the columns in this line
-        do {
+        // Since the CSV has column headers use them to construct an associative array for the columns in this line.
+        // Check valid() before current(): SplFileObject::current() returns false at EOF, and a do-while would
+        // still enter the body once when the iterator is already invalid (e.g. OneToManyReader calls current()
+        // after next() past the last detail row), causing count(false) TypeError on PHP 8+.
+        while ($this->valid()) {
             $line = $this->file->current();
 
             // In non-strict mode pad/slice the line to match the column headers
@@ -135,7 +138,7 @@ class CsvReader implements CountableReader, \SeekableIterator
                 $this->errors[$this->key()] = $line;
                 $this->next();
             }
-        } while($this->valid());
+        }
 
         return null;
     }

--- a/tests/CsvReaderTest.php
+++ b/tests/CsvReaderTest.php
@@ -265,6 +265,97 @@ class CsvReaderTest extends TestCase
         }
     }
 
+    /**
+     * When the iterator is already at EOF, current() must return null rather than
+     * calling count() on SplFileObject's false (do-while entered once while invalid).
+     *
+     * @see https://github.com/portphp/csv/pull/3
+     */
+    public function testCurrentAtEndOfFileWithHeadersReturnsNull()
+    {
+        $file = new \SplTempFileObject();
+        $file->fwrite("id,name\n1,Alice\n2,Bob\n");
+        $file->rewind();
+
+        $reader = new CsvReader($file);
+        $reader->setHeaderRowNumber(0);
+
+        // Exhaust the iterator
+        iterator_to_array($reader);
+
+        $this->assertFalse($reader->valid());
+        $this->assertNull($reader->current());
+    }
+
+    /**
+     * getRow() past the last line should not TypeError on count(false).
+     *
+     * @see https://github.com/portphp/csv/pull/3
+     */
+    public function testGetRowPastEndWithHeadersReturnsNull()
+    {
+        $file = new \SplTempFileObject();
+        $file->fwrite("id,name\n1,Alice\n");
+        $file->rewind();
+
+        $reader = new CsvReader($file);
+        $reader->setHeaderRowNumber(0);
+
+        $this->assertNull($reader->getRow(99));
+    }
+
+    /**
+     * OneToManyReader calls rightReader->current() after next() past the last
+     * detail row. Without checking valid() first, CsvReader::current() hit
+     * count(false) and broke joins on the last master row.
+     *
+     * This is the real-world failure reported against PR #3.
+     *
+     * @see https://github.com/portphp/csv/pull/3
+     * @see https://github.com/portphp/csv/pull/3#issuecomment-769855101
+     */
+    public function testOneToManyReaderConsumesLastDetailRowWithoutError()
+    {
+        $masterFile = new \SplTempFileObject();
+        $masterFile->fwrite("id,name\n1,Alice\n2,Bob\n");
+        $masterFile->rewind();
+        $masterReader = new CsvReader($masterFile);
+        $masterReader->setHeaderRowNumber(0);
+
+        $detailFile = new \SplTempFileObject();
+        $detailFile->fwrite("id,item\n1,apple\n1,banana\n2,carrot\n");
+        $detailFile->rewind();
+        $detailReader = new CsvReader($detailFile);
+        $detailReader->setHeaderRowNumber(0);
+
+        $reader = new \Port\Reader\OneToManyReader(
+            $masterReader,
+            $detailReader,
+            'items',
+            'id',
+            'id'
+        );
+
+        $rows = iterator_to_array($reader);
+
+        $this->assertCount(2, $rows);
+        $this->assertEquals('Alice', $rows[1]['name']);
+        $this->assertEquals(
+            array(
+                array('id' => '1', 'item' => 'apple'),
+                array('id' => '1', 'item' => 'banana'),
+            ),
+            $rows[1]['items']
+        );
+        $this->assertEquals('Bob', $rows[2]['name']);
+        $this->assertEquals(
+            array(
+                array('id' => '2', 'item' => 'carrot'),
+            ),
+            $rows[2]['items']
+        );
+    }
+
     protected function getReader($filename)
     {
         $file = new \SplFileObject(__DIR__.'/fixtures/'.$filename);


### PR DESCRIPTION
## Summary

Replaces / supersedes #3 with the same core fix **plus** a reproducible PHPUnit suite.

`CsvReader::current()` used `do { … } while ($this->valid())` when column headers were set. `SplFileObject::current()` returns **`false` at EOF**. A `do-while` always runs its body once, so calling `current()` while the iterator is already invalid executed `count(false)` and threw:

```
TypeError: count(): Argument #1 ($value) must be of type Countable|array, false given
```

### Why #3’s author could not reproduce

Simple “last line of a normal CSV” fixtures never call `current()` after the iterator is invalid. Foreach only calls `current()` when `valid()` is true, so the do-while body always started on a real line. Trailing newline / short last line / strict mode alone do **not** hit this path.

### Real-world trigger (also noted on #3)

`Port\Reader\OneToManyReader` does:

```php
$this->rightReader->next();
$rightRow = $this->rightReader->current(); // may be past last detail row
if ($this->rightReader->valid()) {
    $rightId = $this->getRowId($rightRow, …);
}
```

After the last matching detail row, `next()` leaves the detail `CsvReader` invalid, then `current()` is still invoked. That is exactly when the do-while blows up—so the **last master row** never completes. Matches the [comment on #3](https://github.com/portphp/csv/pull/3#issuecomment-769855101) about OneToManyReader.

Direct calls after exhaustion (`getRow(99)`, `current()` after `iterator_to_array`) hit the same bug.

## Fix

Same idea as #3: only read a line when valid:

```php
while ($this->valid()) {
    $line = $this->file->current();
    // …
}
return null;
```

## Tests

Three new tests (all **error with TypeError on unfixed master**, pass with this patch):

1. `testCurrentAtEndOfFileWithHeadersReturnsNull` — call `current()` after exhausting the reader  
2. `testGetRowPastEndWithHeadersReturnsNull` — `getRow(99)`  
3. `testOneToManyReaderConsumesLastDetailRowWithoutError` — full master/detail join through the last rows  

Verified locally:

- Without fix: 3 errors (`count(false)`)  
- With fix: 3 tests / assertions green  
- Existing CsvReader tests still pass  

## Recommendation for #3

**Close #3** in favor of this PR (same fix + tests + “Closes #3”). Do not merge #3 alone without tests.

## Checklist

- [x] Bug reproduced with a failing test on master  
- [x] Fix applied (while + valid check)  
- [x] Tests pass with fix  
- [ ] CI green  
- [ ] Review  

**Not merging yet** — waiting on CI/review per housekeeping guidance.